### PR TITLE
check existence of expected headers

### DIFF
--- a/src/manetu/gitlab/api.clj
+++ b/src/manetu/gitlab/api.clj
@@ -51,6 +51,8 @@
                                              (m/map-vals #(Integer/parseInt %) $))]
      (when (and (>= status 200) (< status 400))
        (let [acc (concat acc body)]
-         (if (>= x-page x-total-pages)
-           acc
+         (if (or (nil? x-total-pages) (nil? x-page) (>= x-page x-total-pages))
+           (do
+             (log/debug "invoke-allpages complete x-total-pages:" x-total-pages "x-page:" x-page)
+             acc)
            (recur acc (inc x-page))))))))


### PR DESCRIPTION
... do not depend on returned headers such as x-total-pages. It could give raise to false negatives. Given return HTTP return code is good Better for caller to fail on bad return data (if indeed data is bad) than fail to return good data.